### PR TITLE
Fix contract v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Swanky Phala CLI Tool
 > **Note:** Feedback and contributions are welcome. Please add issues for any features or bugs found. Join our [discord](https://discord.gg/phala) and jump in our `#dev` channel to speak with our devs.  
+## Contract Build Requirements
+
+Ensure your rust toolchain requirements are installed correctly to ensure your contracts can be built correctly.
+
+| Rust Toolchain | Requirement                              | 
+|----------------|------------------------------------------|
+| cargo          | <= `cargo 1.69.0 (6e9a83356 2023-04-12)`  |
+| cargo-contract | <= `3.0.1-unknown-x86_64-unknown-linux-gnu` |
+| target         | `wasm32-unknown-unknown`                   |
+| component      | `rust-src`                                 |               |
 
 ## Swanky Suite
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@phala/swanky-plugin-phala",
   "description": "Phala plugin for Swanky CLI tool",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "author": "Phala Network",
   "bin": {
     "phala": "./bin/run"

--- a/src/templates/contracts/pink/blank/contract/Cargo.toml.hbs
+++ b/src/templates/contracts/pink/blank/contract/Cargo.toml.hbs
@@ -15,10 +15,6 @@ pink-extension = { version = "0.4.2", default-features = false }
 [lib]
 name = "{{contract_name_snake}}"
 path = "src/lib.rs"
-crate-type = [
-	# Used for normal contract Wasm blobs.
-	"cdylib",
-]
 
 [features]
 default = ["std"]

--- a/src/templates/contracts/pink/blank/contract/src/lib.rs.hbs
+++ b/src/templates/contracts/pink/blank/contract/src/lib.rs.hbs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
 extern crate alloc;
 
 // pink_extension is short for Phala ink! extension

--- a/src/templates/contracts/pink/flipper/contract/Cargo.toml.hbs
+++ b/src/templates/contracts/pink/flipper/contract/Cargo.toml.hbs
@@ -15,10 +15,6 @@ pink-extension = { version = "0.4.2", default-features = false }
 [lib]
 name = "{{contract_name_snake}}"
 path = "src/lib.rs"
-crate-type = [
-	# Used for normal contract Wasm blobs.
-	"cdylib",
-]
 
 [features]
 default = ["std"]

--- a/src/templates/contracts/pink/flipper/contract/src/lib.rs.hbs
+++ b/src/templates/contracts/pink/flipper/contract/src/lib.rs.hbs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
 
 use ink;
 

--- a/src/templates/contracts/pink/http_client/contract/Cargo.toml.hbs
+++ b/src/templates/contracts/pink/http_client/contract/Cargo.toml.hbs
@@ -15,10 +15,6 @@ pink-extension = { version = "0.4.2", default-features = false }
 [lib]
 name = "{{contract_name_snake}}"
 path = "src/lib.rs"
-crate-type = [
-	# Used for normal contract Wasm blobs.
-	"cdylib",
-]
 
 [features]
 default = ["std"]

--- a/src/templates/contracts/pink/http_client/contract/src/lib.rs.hbs
+++ b/src/templates/contracts/pink/http_client/contract/src/lib.rs.hbs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
 extern crate alloc;
 
 use pink_extension as pink;

--- a/src/templates/contracts/pink/phat_hello/contract/Cargo.toml.hbs
+++ b/src/templates/contracts/pink/phat_hello/contract/Cargo.toml.hbs
@@ -21,11 +21,6 @@ pink-extension-runtime = "0.4"
 name = "{{contract_name_snake}}"
 path = "src/lib.rs"
 
-crate-type = [
-	# Used for normal contract Wasm blobs.
-	"cdylib",
-]
-
 [features]
 default = ["std"]
 std = [

--- a/src/templates/contracts/pink/phat_hello/contract/src/lib.rs.hbs
+++ b/src/templates/contracts/pink/phat_hello/contract/src/lib.rs.hbs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
 extern crate alloc;
 
 // pink_extension is short for Phala ink! extension

--- a/src/templates/contracts/pink/phat_storage/contract/Cargo.toml.hbs
+++ b/src/templates/contracts/pink/phat_storage/contract/Cargo.toml.hbs
@@ -16,10 +16,6 @@ pink-s3 = { version = "0.4.1", default-features = false }
 [lib]
 name = "{{contract_name_snake}}"
 path = "src/lib.rs"
-crate-type = [
-	# Used for normal contract Wasm blobs.
-	"cdylib",
-]
 
 [features]
 default = ["std"]

--- a/src/templates/contracts/pink/phat_storage/contract/src/lib.rs.hbs
+++ b/src/templates/contracts/pink/phat_storage/contract/src/lib.rs.hbs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
 extern crate alloc;
 use pink_extension as pink;
 

--- a/src/templates/contracts/pink/signing/contract/Cargo.toml.hbs
+++ b/src/templates/contracts/pink/signing/contract/Cargo.toml.hbs
@@ -19,11 +19,6 @@ pink-extension-runtime = "0.4"
 name = "{{contract_name_snake}}"
 path = "src/lib.rs"
 
-crate-type = [
-	# Used for normal contract Wasm blobs.
-	"cdylib",
-]
-
 [features]
 default = ["std"]
 std = [

--- a/src/templates/contracts/pink/signing/contract/src/lib.rs.hbs
+++ b/src/templates/contracts/pink/signing/contract/src/lib.rs.hbs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
 extern crate alloc;
 
 use pink_extension as pink;

--- a/src/templates/contracts/pink/use_cache/contract/Cargo.toml.hbs
+++ b/src/templates/contracts/pink/use_cache/contract/Cargo.toml.hbs
@@ -15,10 +15,6 @@ pink-extension = { version = "0.4.2", default-features = false }
 [lib]
 name = "{{contract_name_snake}}"
 path = "src/lib.rs"
-crate-type = [
-	# Used for normal contract Wasm blobs.
-	"cdylib",
-]
 
 [features]
 default = ["std"]

--- a/src/templates/contracts/pink/use_cache/contract/src/lib.rs.hbs
+++ b/src/templates/contracts/pink/use_cache/contract/src/lib.rs.hbs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
 extern crate alloc;
 use pink_extension as pink;
 


### PR DESCRIPTION
## Description
Fix Contracts to build with latest version of `cargo-contract` v3. Link to breaking change https://github.com/paritytech/cargo-contract/releases/tag/v3.0.0

## Targets
- [x] Update all Phat Contract templates to add `no_main` to `#![cfg_attr(not(feature = "std"), no_std)]`
- [x] Remove `crate_type=[cdylib]` from `Cargo.toml` files
- [x] Add rust toolchain info to notify devs of latest versions, target & component to build a Phat Contract 

Related to issue #13 
